### PR TITLE
Optimized for forward searches from the current cursor pos

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -43,6 +43,7 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 	searchingPhrase := []byte("\r\n\r\nFrom ")
 	sequence := make(SequenceMap)
 
+	lastPos := 0
 	letters := make([]byte, 0)
 	buf := make([]byte, 4*Kb)
 
@@ -61,8 +62,8 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 		letters = append(letters, buf...)
 
 		for {
-			if posEnding := bytes.Index(letters, searchingPhrase); posEnding > -1 {
-				posEnding += 4 // last [\r\n]+
+			if posEnding := bytes.Index(letters[lastPos:], searchingPhrase); posEnding > -1 {
+				posEnding += lastPos + 4 // last [\r\n]+
 
 				filename := sequence.ToUnique(getLetterId(letters[:posEnding]), ".eml")
 				filepath := path.Join(destinationDir, filename)
@@ -73,9 +74,11 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 				}
 
 				letters = letters[posEnding:]
+				lastPos = 0
 
 			} else {
 
+				lastPos = len(letters)
 				break
 
 			}


### PR DESCRIPTION
Optimized for forward searches from the current cursor. Without cursor position persistence, searches default to the buffer's beginning, resulting in performance degradation and potential doubling of execution time.