### PR TITLE
Addition to previous optimization

### DIFF
--- a/extractor.go
+++ b/extractor.go
@@ -74,7 +74,7 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 				}
 
 				letters = letters[posEnding:]
-				lastPos = 0
+				lastPos = len(letters)
 
 			} else {
 

--- a/extractor.go
+++ b/extractor.go
@@ -43,7 +43,7 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 	searchingPhrase := []byte("\r\n\r\nFrom ")
 	sequence := make(SequenceMap)
 
-	lastPos := 0
+	cursor := 0
 	letters := make([]byte, 0)
 	buf := make([]byte, 4*Kb)
 
@@ -62,8 +62,8 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 		letters = append(letters, buf...)
 
 		for {
-			if posEnding := bytes.Index(letters[lastPos:], searchingPhrase); posEnding > -1 {
-				posEnding += lastPos + 4 // last [\r\n]+
+			if posEnding := bytes.Index(letters[cursor:], searchingPhrase); posEnding > -1 {
+				posEnding += cursor + 4 // last [\r\n]+
 
 				filename := sequence.ToUnique(getLetterId(letters[:posEnding]), ".eml")
 				filepath := path.Join(destinationDir, filename)
@@ -74,11 +74,11 @@ func ExtractTo(destinationDir, mboxFpath string) error {
 				}
 
 				letters = letters[posEnding:]
-				lastPos = len(letters)
+				cursor = len(letters)
 
 			} else {
 
-				lastPos = len(letters)
+				cursor = len(letters)
 				break
 
 			}


### PR DESCRIPTION
Minor optimizations within prev PR ( #2 ):

|            |     sec/op       |       B/op       |     allocs/op      |
| :---       |             ---: |             ---: |               ---: |
| benchmark1 | 8.084µ ± 20%     | 4.810Ki ± 6%     |         1.000 ± 0% |
| benchmark2 | 8.347µ ± 33%     | 4.802Ki ± 9%     |         1.000 ± 0% |
| vs base    | ~ (p=0.739 n=10) | ~ (p=0.529 n=10) | ~ (p=1.000 n=10) ¹ |

¹ all samples are equal
